### PR TITLE
[🐸 Frogbot] Update version of org.springframework.security:spring-security-web to 5.7.13

### DIFF
--- a/examples/spring-mvc-webapp/pom.xml
+++ b/examples/spring-mvc-webapp/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.version>5.1.13.RELEASE</spring.version>
-        <spring.security.version>5.1.13.RELEASE</spring.security.version>
+        <spring.security.version>5.7.13</spring.security.version>
         <jetty.version>9.4.34.v20201102</jetty.version>
     </properties>
 

--- a/modules/spring-mock-mvc/pom.xml
+++ b/modules/spring-mock-mvc/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.version>5.1.13.RELEASE</spring.version>
-        <spring.security.version>5.1.13.RELEASE</spring.security.version>
+        <spring.security.version>5.7.13</spring.security.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>



### 📦 Vulnerable Dependencies

<div align='center'>

| Severity                | ID                  | Contextual Analysis                  | Direct Dependencies                  | Impacted Dependency                  | Fixed Versions                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![high](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableHighSeverity.png)<br>    High | CVE-2021-22112 | Applicable | io.rest-assured:spring-mock-mvc:5.5.6-SNAPSHOT<br>org.springframework.security:spring-security-web:5.1.13.RELEASE<br>org.springframework.security:spring-security-test:5.1.13.RELEASE | org.springframework.security:spring-security-web 5.1.13.RELEASE | [5.2.9]<br>[5.3.8]<br>[5.4.4] |

</div>


### 🔖 Details



### Vulnerability Details
|                 |                   |
| --------------------- | :-----------------------------------: |
| **Policies:** | policy-sanity_maven_rest_assured_commit-1755008931 |
| **Watch Name:** | watch-sanity_maven_rest_assured_commit-1755008931 |
| **Contextual Analysis:** | Applicable |
| **Direct Dependencies:** | io.rest-assured:spring-mock-mvc:5.5.6-SNAPSHOT, org.springframework.security:spring-security-web:5.1.13.RELEASE, org.springframework.security:spring-security-test:5.1.13.RELEASE |
| **Impacted Dependency:** | org.springframework.security:spring-security-web:5.1.13.RELEASE |
| **Fixed Versions:** | [5.2.9], [5.3.8], [5.4.4] |
| **CVSS V3:** | 8.8 |

Spring Security 5.4.x prior to 5.4.4, 5.3.x prior to 5.3.8.RELEASE, 5.2.x prior to 5.2.9.RELEASE, and older unsupported versions can fail to save the SecurityContext if it is changed more than once in a single request.A malicious user cannot cause the bug to happen (it must be programmed in). However, if the application's intent is to only allow the user to run with elevated privileges in a small portion of the application, the bug can be leveraged to extend those privileges to the rest of the application.


---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>
